### PR TITLE
Fixed spelling mistake in appinfo/routes.php

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -22,7 +22,7 @@ return [
 	'routes' => [
 		//internal ADMIN API
 		['name' => 'admin#reset', 'url' => '/admin/reset', 'verb' => 'GET'],
-		['name' => 'admin#clearALlJobs', 'url' => '/admin/clearJobs', 'verb' => 'GET'],
+		['name' => 'admin#clearAllJobs', 'url' => '/admin/clearJobs', 'verb' => 'GET'],
 		['name' => 'admin#recrawl', 'url' => '/admin/recrawl', 'verb' => 'GET'],
 		['name' => 'admin#reset_faces', 'url' => '/admin/resetFaces', 'verb' => 'GET'],
 		['name' => 'admin#count', 'url' => '/admin/count', 'verb' => 'GET'],


### PR DESCRIPTION
Changed 'admin#clearALlJobs' to 'admin#clearAllJobs'.

Seeing as the name isn't used anywhere else in the entire project this should be fine.